### PR TITLE
Update windows.md binary path build

### DIFF
--- a/content/getting-started/windows.md
+++ b/content/getting-started/windows.md
@@ -33,7 +33,7 @@ Download the source code for OpenCV Contrib master branch from [https://github.c
 
 Create the directory `C:\opencv\build` as the build directory.
 
-Now launch the `cmake-gui` program, and set the "Where is the source code" to `C:\opencv\opencv-3.3.0`, and the "Where to build the binaries" to `C:\opencv3\build`.
+Now launch the `cmake-gui` program, and set the "Where is the source code" to `C:\opencv\opencv-3.3.0`, and the "Where to build the binaries" to `C:\opencv\build`.
 
 Click on "Configure" and select "MinGW MakeFile" from the window, then click on the  "Next" button.
 


### PR DESCRIPTION
There was a typo on the build binary path. Changed from c:\opencv3\build to c:\opencv\build