### PR TITLE
Update osx.md

### DIFF
--- a/content/getting-started/osx.md
+++ b/content/getting-started/osx.md
@@ -27,7 +27,7 @@ In order to build/run Go code that uses this package, you will need to specify t
 
 First, you need to change the current directory to the location of the GoCV repo:
 
-		cd $GOPATH/src/gocv.io/x/gocv
+		cd $GOROOT/src/gocv.io/x/gocv
 
 One time per session, you must run the script:
 


### PR DESCRIPTION
To my understanding $GOPATH (as was originally referenced) is the path to compiled go binaries for interpretation by the system. e.g. ~/go/bin. As such there is no $GOPATH/src directory. $GOROOT is typically the parent directory of $GOPATH which does contain the expected src directory.