### PR TITLE
Update linux.md

### DIFF
--- a/content/getting-started/linux.md
+++ b/content/getting-started/linux.md
@@ -17,7 +17,7 @@ Install the GoCV package:
 
 Change directories into the newly installed package directory:
 
-        cd $GOPATH/src/gocv.io/x/gocv
+        cd $GOROOT/src/gocv.io/x/gocv
 
 Now you can run the needed installation steps listed below.
 


### PR DESCRIPTION
To my understanding $GOPATH (as was originally referenced) is the path to compiled go binaries for interpretation by the system. e.g. ~/go/bin. As such there is no $GOPATH/src directory. $GOROOT is typically the parent directory of $GOPATH which does contain the expected src directory.