### PR TITLE
Correct make clean instruction

### DIFF
--- a/content/getting-started/linux.md
+++ b/content/getting-started/linux.md
@@ -43,7 +43,7 @@ Build and install everything. This will take quite a while:
 
 After the installation is complete, you can remove the extra files and folders:
 
-		make cleanup
+		make clean
 
 ### How to build/run code
 


### PR DESCRIPTION
The PR corrects the `make clean` instruction on the Linux Getting Started page to match the Makefile.