### PR TITLE
Update macos.md

### DIFF
--- a/content/getting-started/macos.md
+++ b/content/getting-started/macos.md
@@ -17,13 +17,14 @@ You can install OpenCV 4.3.0 using Homebrew.
 
 If you already have an earlier version of OpenCV installed, you should update:
 
-	brew update opencv
+	brew upgrade opencv
 
 If this is your first time install OpenCV 4.3.0:
 
 	brew install opencv
 
 ### pkgconfig Installation
+
 pkg-config is used to determine the correct flags for compiling and linking OpenCV.
 You can install it by using Homebrew:
     


### PR DESCRIPTION
Small correction to the brew instructions. 

Running `brew update` is used to update brew, whereas software is upgraded via the `brew upgrade` command. Running the original stated command of `brew update opencv` will just return:
`Error: This command updates brew itself, and does not take formula names.`

Hope this helps clarify for other users.