### PR TITLE
content: Fix the wrong link for Windows installation

### DIFF
--- a/content/getting-started/windows.md
+++ b/content/getting-started/windows.md
@@ -17,7 +17,7 @@ In order to use GoCV on Windows you must build and install OpenCV 4.10.0. First 
 
 #### MinGW-W64
 
-Download and run the MinGW-W64 compiler installer from [https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/7.3.0/](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/7.3.0/).
+Download and run the MinGW-W64 compiler installer from [https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/7.3.0/](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/7.3.0//).
 
 The latest version of the MinGW-W64 toolchain is `7.3.0`, but any version from `7.X` on should work.
 


### PR DESCRIPTION
The originally 32-bit link was changed to 64-bit.