### PR TITLE
Fixed edit links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,7 +6,7 @@ theme = "hugo-theme-relearn"
 [params]
   # Disable search function. It will hide search bar
   disableSearch = true
-  editURL = "https://github.com/hybridgroup/gocv-site/edit/master/content/"
+  editURL = "https://github.com/hybridgroup/gocv-site/edit/release/content/"
   themeVariant = 'learn'
 
 [[menu.shortcuts]] 


### PR DESCRIPTION
It looks like the default branch changed from `master` to `release` at some point, so the edit links stopped working.