### PR TITLE
Added links to getting started index

### DIFF
--- a/content/getting-started/_index.md
+++ b/content/getting-started/_index.md
@@ -6,5 +6,11 @@ chapter: true
 weight: 5
 ---
 
-To use GoCV, you must install OpenCV 4.13.0 on your system. We have instructions for Linux, macOS, and Windows.
+To use GoCV, you must install OpenCV 4.13.0 on your system.
 
+We have instructions for:
+
+- [Linux]({{ ref "/getting-started/linux" }})
+- [macOS]({{ ref "/getting-started/macos" }})
+- [Windows]({{ ref "/getting-started/windows" }})
+- [Docker]({{ ref "/getting-started/docker" }})


### PR DESCRIPTION
It was initially confusing to me to come to this page and find no information about how to actually do the installation. Adding links will make this easier to use.

I'm not able to test this locally because the `hugo` build doesn't seem to output any HTML files.